### PR TITLE
minibus implementation to help migrate from java.util.Observable

### DIFF
--- a/src/main/java/com/github/jneat/minibus/utils/EventBroker.java
+++ b/src/main/java/com/github/jneat/minibus/utils/EventBroker.java
@@ -1,0 +1,102 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2018 by rumatoest at github.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.github.jneat.minibus.utils;
+
+import com.github.jneat.minibus.*;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+
+
+public class EventBroker {
+
+  private static final EventBus<EventBusEvent, EventBusHandler<?>> EVENT_BUS = new EventBusAsync<>();
+  private static final EventBroker INSTANCE = new EventBroker();
+  private final Map<String, EventBusHandler<?>> registry = new HashMap<>();
+
+  public <T extends EventBusEvent> void subscribe(Consumer<T> consumer, Class<T> type, String handlerName) {
+    EventBusHandler<T> handler = new EventBusHandler<T>() {
+      private final Class<T> handlerType = type;
+
+      @Override
+      protected Class<T> getLinkedClass() {
+        return handlerType;
+      }
+
+      @Override
+      public void handle(T event) throws Throwable {
+        consumer.accept(handlerType.cast(event));
+      }
+
+      @Override
+      public void handleEvent(EventBusEvent event) throws Throwable {
+        this.handle(handlerType.cast(event));
+      }
+
+      @Override
+      public boolean canHandle(Class<? extends EventBusEvent> cls) {
+        return handlerType.equals(cls);
+      }
+    };
+    this.subscribe(handler, handlerName);
+
+  }
+
+  public void subscribe(EventBusHandler<?> handler, String handlerName) {
+
+    if (handlerName != null && registry.containsKey(handlerName)) {
+      //already subscribed
+      return;
+    } else {
+      registry.put(handlerName, handler);
+    }
+
+    EVENT_BUS.subscribe(handler);
+  }
+
+  public void unsubscribe(String handlerName) {
+    EventBusHandler<?> handler = registry.get(handlerName);
+    if (handler != null) {
+      EVENT_BUS.unsubscribe(handler);
+      registry.remove(handlerName);
+    }
+  }
+
+
+  public void publish(EventBusEvent event) {
+    EVENT_BUS.publish(event);
+  }
+
+  public void publish(EventBusEvent event, BiConsumer<EventBusEvent, EventBusHandler<?>> success,
+                      FailureConsumer<EventBusEvent, EventBusHandler<?>> failure) {
+    EVENT_BUS.publish(event, success, failure);
+  }
+
+  public static EventBroker getInstance() {
+    return INSTANCE;
+  }
+}

--- a/src/main/java/com/github/jneat/minibus/utils/EventObservable.java
+++ b/src/main/java/com/github/jneat/minibus/utils/EventObservable.java
@@ -1,0 +1,48 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2018 by rumatoest at github.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.github.jneat.minibus.utils;
+
+import com.github.jneat.minibus.EventBusEvent;
+
+/**
+ * A replacement for the now deprecated java.util.Observable pattern
+ * @see java.util.Observable
+ *
+ */
+public interface EventObservable<E extends EventBusEvent> {
+
+    default void notifyObservers(E event){
+      EventBroker.getInstance().publish(event);
+    }
+
+    /*
+    * A replacement method for java.util.Observable.notifyObserver
+    */
+    default void register( EventObserver<E> observer,Class<E> eventType ){
+        EventBroker.getInstance().subscribe(
+                (E event) -> observer.update(this,event), eventType , observer.getObserverName());
+    }
+
+}

--- a/src/main/java/com/github/jneat/minibus/utils/EventObserver.java
+++ b/src/main/java/com/github/jneat/minibus/utils/EventObserver.java
@@ -1,0 +1,41 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2018 by rumatoest at github.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.github.jneat.minibus.utils;
+
+import com.github.jneat.minibus.EventBusEvent;
+
+/*
+ * A replacement for the now deprecated java.util.Observer pattern
+ * @see java.util.Observer
+ */
+public interface EventObserver<E extends EventBusEvent> {
+
+    default String getObserverName(){
+        return this.getClass().getName()+"Observer";
+    }
+
+    void update(EventObservable<E> observable, E event);
+
+}

--- a/src/test/java/com/github/jneat/minibus/utils/EventController.java
+++ b/src/test/java/com/github/jneat/minibus/utils/EventController.java
@@ -1,0 +1,34 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2018 by rumatoest at github.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.github.jneat.minibus.utils;
+
+public class EventController implements EventObservable<KeyEvent> {
+
+  public void execute(){
+    // do some business logic here
+    notifyObservers(new KeyEvent("Test Event"));
+  }
+
+}

--- a/src/test/java/com/github/jneat/minibus/utils/EventObservableTest.java
+++ b/src/test/java/com/github/jneat/minibus/utils/EventObservableTest.java
@@ -1,0 +1,38 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2018 by rumatoest at github.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.github.jneat.minibus.utils;
+
+import org.testng.annotations.Test;
+
+public class EventObservableTest {
+
+  @Test
+  public void notifyObservers() throws Exception {
+    EventController controller = new EventController();
+    EventUIFormPanel panel = new EventUIFormPanel();
+    controller.register(panel,KeyEvent.class);
+    controller.execute();
+  }
+}

--- a/src/test/java/com/github/jneat/minibus/utils/EventUIFormPanel.java
+++ b/src/test/java/com/github/jneat/minibus/utils/EventUIFormPanel.java
@@ -1,0 +1,34 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2018 by rumatoest at github.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.github.jneat.minibus.utils;
+
+public class EventUIFormPanel implements EventObserver<KeyEvent>{
+
+
+  @Override
+  public void update(EventObservable<KeyEvent> observable, KeyEvent event) {
+    System.out.println("Updating some UI components for event:"+event.getKey());
+  }
+}

--- a/src/test/java/com/github/jneat/minibus/utils/KeyEvent.java
+++ b/src/test/java/com/github/jneat/minibus/utils/KeyEvent.java
@@ -1,0 +1,43 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2018 by rumatoest at github.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.github.jneat.minibus.utils;
+
+import com.github.jneat.minibus.EventBusEvent;
+
+public class KeyEvent implements EventBusEvent {
+  private String key;
+
+  public KeyEvent(String key) {
+    this.key = key;
+  }
+
+  public String getKey() {
+    return key;
+  }
+
+  public void setKey(String key) {
+    this.key = key;
+  }
+}


### PR DESCRIPTION
Why?
Java JDK has deprecated their `java.util.Observable` pattern since Java 9.
Use minibus as a supplement for anyone that would like to remove this deprecation from their code base.

How?
While these util classes have slightly minor api signature difference. It's very easy to refactor the deprecated code and replace it with the `EventObserver/EventObservable` equivalent.  The `EventBroker` helps abstract out some implementation details by providing `lambda` API functions instead so that the user does not have to implement Handlers in their code.