### PR TITLE
Improvements with generics and passive waiting

### DIFF
--- a/src/main/java/com/github/jneat/minibus/EventBus.java
+++ b/src/main/java/com/github/jneat/minibus/EventBus.java
@@ -34,7 +34,7 @@ public interface EventBus<E extends EventBusEvent, H extends EventBusHandler<?>>
 
     /**
      * Subscribe consumer to the event bus using weak link.
-     *
+     * <p>
      * Subscribing same object twice should not affect how many times subscriber will
      * be called per one event.
      *
@@ -53,7 +53,7 @@ public interface EventBus<E extends EventBusEvent, H extends EventBusHandler<?>>
 
     /**
      * Sends a event (message) to the bus which will be propagated to the appropriate subscribers (handlers).
-     *
+     * <p>
      * There is no specification given as to how the messages will be delivered,
      * and should be determine in each implementation.
      *

--- a/src/main/java/com/github/jneat/minibus/EventBusAsync.java
+++ b/src/main/java/com/github/jneat/minibus/EventBusAsync.java
@@ -2,24 +2,24 @@
  * The MIT License (MIT)
  *
  * Copyright (c) 2018 by rumatoest at github.com
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in all
  * copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
  * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
  * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
- * SOFTWARE. 
+ * SOFTWARE.
  */
 package com.github.jneat.minibus;
 
@@ -38,20 +38,18 @@ import java.util.concurrent.Executors;
 import java.util.function.BiConsumer;
 
 /**
- * Async event bus that will run each event/handler call in separate thread.
- * By default using CachedThreadPool to run handlers.
+ * Async event bus that will run each event/handler call in separate thread. By default using CachedThreadPool to run
+ * handlers.
  */
 public class EventBusAsync<E extends EventBusEvent, H extends EventBusHandler<?>> implements EventBus<E, H> {
 
     private static final Logger logger = LoggerFactory.getLogger(EventBusAsync.class);
 
-    private final Thread eventQueueThread;
-
     private final Queue<EventWrapper<E, H>> eventsQueue = new ConcurrentLinkedQueue<>();
 
-    private final ReferenceQueue gcQueue = new ReferenceQueue();
+    private final ReferenceQueue<H> gcQueue = new ReferenceQueue<>();
 
-    private final Map<Class, Set<WeakHandler<H>>> handlersCls = new ConcurrentHashMap<>();
+    private final Map<Class<?>, Set<WeakHandler<H>>> handlersCls = new ConcurrentHashMap<>();
 
     private final Set<WeakHandler<H>> handlers = Collections.newSetFromMap(new ConcurrentHashMap<>());
 
@@ -60,16 +58,15 @@ public class EventBusAsync<E extends EventBusEvent, H extends EventBusHandler<?>
     private final int sleepMs;
 
     /**
-     * CAN OVERRIDE THIS METHOD.
-     * If you need to add some weirdo filters to events right before handler will be submitted to executor.
+     * CAN OVERRIDE THIS METHOD. If you need to add some weirdo filters to events right before handler will be submitted
+     * to executor.
      */
     protected void submitHandler(H h, EventWrapper<E, H> ew) {
         handlersExecutor.submit(() -> runHandlerWrapper(h, ew));
     }
 
     /**
-     * CAN OVERRIDE THIS METHOD.
-     * This executes in separate thread, passing event to handler
+     * CAN OVERRIDE THIS METHOD. This executes in separate thread, passing event to handler
      */
     protected void runHandler(H h, E e) throws Throwable {
         h.handleEvent(e);
@@ -89,7 +86,7 @@ public class EventBusAsync<E extends EventBusEvent, H extends EventBusHandler<?>
      */
     public EventBusAsync(ExecutorService handlersExecutor) {
         this.handlersExecutor = handlersExecutor;
-        eventQueueThread = new Thread(this::eventsQueue, "EventQueue handlers thread");
+        Thread eventQueueThread = new Thread(this::eventsQueue, "EventQueue handlers thread");
         eventQueueThread.setDaemon(true);
         eventQueueThread.start();
         // Possibly will make it as configurable variable
@@ -100,28 +97,24 @@ public class EventBusAsync<E extends EventBusEvent, H extends EventBusHandler<?>
     public void subscribe(H subscriber) {
         Class<? extends EventBusEvent> cls = subscriber.getLinkedClass();
         if (cls == null) {
-            handlers.add(new WeakHandler(subscriber, gcQueue));
+            handlers.add(new WeakHandler<>(subscriber, gcQueue));
         } else {
             synchronized (this) {
-                Set<WeakHandler<H>> hs = handlersCls.get(cls);
-                if (hs == null) {
-                    hs = Collections.newSetFromMap(new ConcurrentHashMap<>());
-                    handlersCls.put(cls, hs);
-                }
-                hs.add(new WeakHandler(subscriber, gcQueue));
+                Set<WeakHandler<H>> hs = handlersCls.computeIfAbsent(cls, k -> Collections.newSetFromMap(new ConcurrentHashMap<>()));
+                hs.add(new WeakHandler<>(subscriber, gcQueue));
             }
         }
     }
 
     @Override
     public void unsubscribe(H subscriber) {
-        Class cls = subscriber.getLinkedClass();
+        Class<?> cls = subscriber.getLinkedClass();
         if (cls == null) {
-            handlers.remove(new WeakHandler(subscriber, gcQueue));
+            handlers.remove(new WeakHandler<>(subscriber, gcQueue));
         } else {
             Set<WeakHandler<H>> set = handlersCls.get(cls);
             if (set != null) {
-                set.remove(new WeakHandler(subscriber, gcQueue));
+                set.remove(new WeakHandler<>(subscriber, gcQueue));
             }
         }
     }
@@ -146,9 +139,9 @@ public class EventBusAsync<E extends EventBusEvent, H extends EventBusHandler<?>
 
     private void eventsQueue() {
         while (true) {
-            WeakHandler wh;
-            while ((wh = (WeakHandler)gcQueue.poll()) != null) {
-                Class cls = wh.getHandlerTypeClass();
+            WeakHandler<?> wh;
+            while ((wh = (WeakHandler<?>) gcQueue.poll()) != null) {
+                Class<?> cls = wh.getHandlerTypeClass();
                 if (cls == null) {
                     handlers.remove(wh);
                 } else {
@@ -188,13 +181,12 @@ public class EventBusAsync<E extends EventBusEvent, H extends EventBusHandler<?>
 
             for (WeakHandler<H> wh : handlers) {
                 H eh = wh.get();
-                if (eh.canHandle(ew.event.getClass())) {
+                if (eh != null && eh.canHandle(ew.event.getClass())) {
                     submitHandler(eh, ew);
                 }
             }
         } catch (Throwable th) {
-            logger.error("Event processing fail " + ew.event.getClass().getSimpleName()
-                + ". " + th.getMessage(), th);
+            logger.error("Event processing fail {}. {}", ew.event.getClass().getSimpleName(), th.getMessage(), th);
         }
     }
 
@@ -205,9 +197,7 @@ public class EventBusAsync<E extends EventBusEvent, H extends EventBusHandler<?>
                 ew.success.accept(ew.event, handler);
             }
         } catch (Throwable th) {
-            logger.error("Handler " + handler.getClass().getSimpleName()
-                + " fail on event " + ew.event.getClass().getSimpleName()
-                + ". " + th.getMessage(), th);
+            logger.error("Handler {} fail on event {}. {}", handler.getClass().getSimpleName(), ew.event.getClass().getSimpleName(), th.getMessage(), th);
             if (ew.failure != null) {
                 ew.failure.accept(ew.event, handler, th);
             }

--- a/src/main/java/com/github/jneat/minibus/EventBusEvent.java
+++ b/src/main/java/com/github/jneat/minibus/EventBusEvent.java
@@ -27,7 +27,7 @@ package com.github.jneat.minibus;
  * Immutable Event that can be processed in EventBus.
  * Note that you should take care about your events immutability.
  * We suggest you to use only final properties, and in a case if you need builder
- * for your message, you can use lombock (https://projectlombok.org) library for this purpose.
+ * for your message, you can use <a href="https://projectlombok.org">project lombok</a> library for this purpose.
  */
 public interface EventBusEvent {
 }

--- a/src/main/java/com/github/jneat/minibus/EventBusHandler.java
+++ b/src/main/java/com/github/jneat/minibus/EventBusHandler.java
@@ -36,6 +36,7 @@ public abstract class EventBusHandler<E extends EventBusEvent> {
 
     private Class<E> getGenericTypeClass() {
         if (eventClass == null) {
+            //noinspection unchecked
             eventClass = (Class<E>)((ParameterizedType)getClass()
                 .getGenericSuperclass())
                 .getActualTypeArguments()[0];

--- a/src/main/java/com/github/jneat/minibus/EventWrapper.java
+++ b/src/main/java/com/github/jneat/minibus/EventWrapper.java
@@ -2,24 +2,24 @@
  * The MIT License (MIT)
  *
  * Copyright (c) 2018 by rumatoest at github.com
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in all
  * copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
  * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
  * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
- * SOFTWARE. 
+ * SOFTWARE.
  */
 package com.github.jneat.minibus;
 

--- a/src/main/java/com/github/jneat/minibus/WeakHandler.java
+++ b/src/main/java/com/github/jneat/minibus/WeakHandler.java
@@ -2,24 +2,24 @@
  * The MIT License (MIT)
  *
  * Copyright (c) 2018 by rumatoest at github.com
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in all
  * copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
  * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
  * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
- * SOFTWARE. 
+ * SOFTWARE.
  */
 package com.github.jneat.minibus;
 
@@ -29,19 +29,19 @@ import java.lang.ref.WeakReference;
 /**
  * Provide weak link wrapper for handler class and expose some generic handlers methods.
  */
-class WeakHandler<H extends EventBusHandler> extends WeakReference<H> {
+class WeakHandler<H extends EventBusHandler<?>> extends WeakReference<H> {
 
     private final int hash;
 
-    private final Class handlerTypeClass;
+    private final Class<?> handlerTypeClass;
 
-    WeakHandler(H handler, ReferenceQueue q) {
+    WeakHandler(H handler, ReferenceQueue<H> q) {
         super(handler, q);
         hash = handler.hashCode();
         handlerTypeClass = handler.getLinkedClass();
     }
 
-    public Class getHandlerTypeClass() {
+    public Class<?> getHandlerTypeClass() {
         return handlerTypeClass;
     }
 
@@ -60,7 +60,8 @@ class WeakHandler<H extends EventBusHandler> extends WeakReference<H> {
         }
 
         Object t = this.get();
-        Object u = ((WeakHandler)obj).get();
+        @SuppressWarnings("unchecked")
+        Object u = ((WeakHandler<H>) obj).get();
         if (t == u) {
             return true;
         }

--- a/src/main/java/com/github/jneat/minibus/utils/EventObserver.java
+++ b/src/main/java/com/github/jneat/minibus/utils/EventObserver.java
@@ -26,14 +26,15 @@ package com.github.jneat.minibus.utils;
 
 import com.github.jneat.minibus.EventBusEvent;
 
-/*
+/**
  * A replacement for the now deprecated java.util.Observer pattern
+ *
  * @see java.util.Observer
  */
 public interface EventObserver<E extends EventBusEvent> {
 
-    default String getObserverName(){
-        return this.getClass().getName()+"Observer";
+    default String getObserverName() {
+        return this.getClass().getName() + "Observer";
     }
 
     void update(EventObservable<E> observable, E event);

--- a/src/test/java/com/github/jneat/minibus/EventBusAsyncTest.java
+++ b/src/test/java/com/github/jneat/minibus/EventBusAsyncTest.java
@@ -1,14 +1,11 @@
 package com.github.jneat.minibus;
 
-import com.github.jneat.minibus.EventBusAsync;
-import com.github.jneat.minibus.EventBus;
-import com.github.jneat.minibus.EventBusSimple;
-import com.github.jneat.minibus.EventBusHandler;
-import static org.assertj.core.api.Assertions.*;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class EventBusAsyncTest {
 
@@ -24,7 +21,6 @@ public class EventBusAsyncTest {
 
     @BeforeClass
     void init() {
-
     }
 
     @Test(priority = 10)

--- a/src/test/java/com/github/jneat/minibus/Handler1.java
+++ b/src/test/java/com/github/jneat/minibus/Handler1.java
@@ -1,6 +1,5 @@
 package com.github.jneat.minibus;
 
-import com.github.jneat.minibus.EventBusHandler;
 import java.util.concurrent.atomic.AtomicInteger;
 
 public class Handler1 extends EventBusHandler<Event1> {

--- a/src/test/java/com/github/jneat/minibus/Handler2.java
+++ b/src/test/java/com/github/jneat/minibus/Handler2.java
@@ -1,6 +1,5 @@
 package com.github.jneat.minibus;
 
-import com.github.jneat.minibus.EventBusHandler;
 import java.util.concurrent.atomic.AtomicInteger;
 
 public class Handler2 extends EventBusHandler<Event2> {

--- a/src/test/java/com/github/jneat/minibus/Handler234.java
+++ b/src/test/java/com/github/jneat/minibus/Handler234.java
@@ -1,7 +1,5 @@
 package com.github.jneat.minibus;
 
-import com.github.jneat.minibus.EventBusEvent;
-import com.github.jneat.minibus.EventBusHandler;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.logging.Logger;
 
@@ -22,16 +20,11 @@ public class Handler234 extends EventBusHandler<EventBusEvent> {
     @Override
     public boolean canHandle(Class<? extends EventBusEvent> cls) {
         boolean h = cls.isAssignableFrom(Event2.class)
-            || cls.isAssignableFrom(Event3.class)
-            || cls.isAssignableFrom(Event4.class);
+                || cls.isAssignableFrom(Event3.class)
+                || cls.isAssignableFrom(Event4.class);
         logger.info("Result " + h + " for " + cls.getCanonicalName());
         return h;
     }
-
-//    @Override
-//    public void handleEvent(EventBusEvent event) {
-//        super.handleEvent(event);
-//    }
 
     @Override
     public void handle(EventBusEvent event) {

--- a/src/test/java/com/github/jneat/minibus/Handler3.java
+++ b/src/test/java/com/github/jneat/minibus/Handler3.java
@@ -1,6 +1,5 @@
 package com.github.jneat.minibus;
 
-import com.github.jneat.minibus.EventBusHandler;
 import java.util.concurrent.atomic.AtomicInteger;
 
 public class Handler3 extends EventBusHandler<Event3> {

--- a/src/test/java/com/github/jneat/minibus/Handler4Error.java
+++ b/src/test/java/com/github/jneat/minibus/Handler4Error.java
@@ -1,7 +1,5 @@
 package com.github.jneat.minibus;
 
-import com.github.jneat.minibus.EventBusHandler;
-
 public class Handler4Error extends EventBusHandler<Event4> {
 
     @Override


### PR DESCRIPTION
To avoid polling and unnecessary load I have converted the EventBusAsync to passive waiting with `wait()` and `notifyAll()`. So there is no need to make the `sleepMs` Field configurable.

Additionally I have reduced several warnings in my IDE (IntelliJ IDEA) and by that introduced a few generics.

Since this is my first pull request on GitHub, I hope everything is all right and my changes can be merged.